### PR TITLE
Implement cleanup and menu improvements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AdminID         int64   `yaml:"admin_id"`
 	PriceUpload     float64 `yaml:"price_upload"`
 	PriceRefund     float64 `yaml:"price_refund"`
+	MenuText        string  `yaml:"menu_text"`
 }
 
 func Load(path string) (*Config, error) {
@@ -62,6 +63,7 @@ func Ensure(path string) (*Config, error) {
 			AdminID:         0,
 			PriceUpload:     1.0,
 			PriceRefund:     0.5,
+			MenuText:        "\xF0\x9F\x92\xB0 Ваш баланс: %%bal%%\n\xF0\x9F\x93\x84 Загрузка: %%price%% USDT\n\xE2\x9E\x95 Возврат за удаление: %%refund%% USDT\nВыберите действие:",
 		}
 		if err := cfg.Save(path); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- delete previous messages and user messages for cleaner chats
- add customizable `menu_text` in config with variables for balance, price and refund
- show informative menu with upload and refund info
- switch admin panel to use reply keyboard

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d4b7534e0832ab2cde1ac574c6773