### PR TITLE
Add download logs with HTML export

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/example/filestoragebot/bot"
 	"github.com/example/filestoragebot/config"
 	"github.com/example/filestoragebot/db"
+	"github.com/example/filestoragebot/logdb"
 	"github.com/example/filestoragebot/server"
 )
 
@@ -31,13 +32,18 @@ func main() {
 		log.Fatalf("database: %v", err)
 	}
 
-	b, err := bot.New(cfg, database)
+	logs, err := logdb.New(cfg.LogsDatabasePath)
+	if err != nil {
+		log.Fatalf("logs database: %v", err)
+	}
+
+	b, err := bot.New(cfg, database, logs)
 	if err != nil {
 		log.Fatalf("bot: %v", err)
 	}
 
 	go func() {
-		if err := server.Start(cfg, database, func(id int64, msg string) {
+		if err := server.Start(cfg, database, logs, func(id int64, msg string) {
 			_ = b.Notify(id, msg)
 		}); err != nil {
 			log.Fatalf("server: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -7,22 +7,23 @@ import (
 )
 
 type Config struct {
-	TelegramToken   string  `yaml:"telegram_token"`
-	CryptoBotToken  string  `yaml:"cryptobot_token"`
-	XRocketToken    string  `yaml:"xrocket_token"`
-	CryptoMinTopup  float64 `yaml:"cryptobot_min_topup"`
-	XRocketMinTopup float64 `yaml:"xrocket_min_topup"`
-	DatabasePath    string  `yaml:"database_path"`
-	FileStoragePath string  `yaml:"file_storage_path"`
-	MaxFileSize     int64   `yaml:"max_file_size"`
-	Domain          string  `yaml:"domain"`
-	HTTPAddress     string  `yaml:"http_address"`
-	TLSCert         string  `yaml:"tls_cert"`
-	TLSKey          string  `yaml:"tls_key"`
-	AdminID         int64   `yaml:"admin_id"`
-	PriceUpload     float64 `yaml:"price_upload"`
-	PriceRefund     float64 `yaml:"price_refund"`
-	MenuText        string  `yaml:"menu_text"`
+	TelegramToken    string  `yaml:"telegram_token"`
+	CryptoBotToken   string  `yaml:"cryptobot_token"`
+	XRocketToken     string  `yaml:"xrocket_token"`
+	CryptoMinTopup   float64 `yaml:"cryptobot_min_topup"`
+	XRocketMinTopup  float64 `yaml:"xrocket_min_topup"`
+	DatabasePath     string  `yaml:"database_path"`
+	LogsDatabasePath string  `yaml:"logs_database_path"`
+	FileStoragePath  string  `yaml:"file_storage_path"`
+	MaxFileSize      int64   `yaml:"max_file_size"`
+	Domain           string  `yaml:"domain"`
+	HTTPAddress      string  `yaml:"http_address"`
+	TLSCert          string  `yaml:"tls_cert"`
+	TLSKey           string  `yaml:"tls_key"`
+	AdminID          int64   `yaml:"admin_id"`
+	PriceUpload      float64 `yaml:"price_upload"`
+	PriceRefund      float64 `yaml:"price_refund"`
+	MenuText         string  `yaml:"menu_text"`
 }
 
 func Load(path string) (*Config, error) {
@@ -48,22 +49,23 @@ func (c *Config) Save(path string) error {
 func Ensure(path string) (*Config, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		cfg := &Config{
-			TelegramToken:   "",
-			CryptoBotToken:  "",
-			XRocketToken:    "",
-			CryptoMinTopup:  0.1,
-			XRocketMinTopup: 0.1,
-			DatabasePath:    "filestorage.db",
-			FileStoragePath: "files",
-			MaxFileSize:     100 * 1024 * 1024,
-			Domain:          "http://localhost:8080",
-			HTTPAddress:     ":8080",
-			TLSCert:         "",
-			TLSKey:          "",
-			AdminID:         0,
-			PriceUpload:     1.0,
-			PriceRefund:     0.5,
-			MenuText:        "\xF0\x9F\x92\xB0 Ваш баланс: %%bal%%\n\xF0\x9F\x93\x84 Загрузка: %%price%% USDT\n\xE2\x9E\x95 Возврат за удаление: %%refund%% USDT\nВыберите действие:",
+			TelegramToken:    "",
+			CryptoBotToken:   "",
+			XRocketToken:     "",
+			CryptoMinTopup:   0.1,
+			XRocketMinTopup:  0.1,
+			DatabasePath:     "filestorage.db",
+			LogsDatabasePath: "logs.db",
+			FileStoragePath:  "files",
+			MaxFileSize:      100 * 1024 * 1024,
+			Domain:           "http://localhost:8080",
+			HTTPAddress:      ":8080",
+			TLSCert:          "",
+			TLSKey:           "",
+			AdminID:          0,
+			PriceUpload:      1.0,
+			PriceRefund:      0.5,
+			MenuText:         "\xF0\x9F\x92\xB0 Ваш баланс: %%bal%%\n\xF0\x9F\x93\x84 Загрузка: %%price%% USDT\n\xE2\x9E\x95 Возврат за удаление: %%refund%% USDT\nВыберите действие:",
 		}
 		if err := cfg.Save(path); err != nil {
 			return nil, err

--- a/logdb/db.go
+++ b/logdb/db.go
@@ -1,0 +1,99 @@
+package logdb
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "modernc.org/sqlite"
+)
+
+// DB handles download logs in a separate SQLite database.
+type DB struct {
+	*sql.DB
+}
+
+// Entry represents a single download event.
+type Entry struct {
+	ID          int64
+	CreatedAt   string
+	IP          string
+	City        string
+	Country     string
+	Platform    string
+	Model       string
+	OSName      string
+	OSVersion   string
+	BrowserName string
+	BrowserVer  string
+}
+
+// New opens database at given path creating file if needed.
+func New(path string) (*DB, error) {
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{database}, nil
+}
+
+func tableName(fileID int64) string {
+	return fmt.Sprintf("log_%d", fileID)
+}
+
+func (db *DB) ensureTable(fileID int64) error {
+	q := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+        id INTEGER PRIMARY KEY,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        ip TEXT,
+        city TEXT,
+        country TEXT,
+        platform TEXT,
+        model TEXT,
+        os_name TEXT,
+        os_version TEXT,
+        browser_name TEXT,
+        browser_ver TEXT
+    );`, tableName(fileID))
+	_, err := db.Exec(q)
+	return err
+}
+
+// Add stores a download entry for given file.
+func (db *DB) Add(fileID int64, e *Entry) error {
+	if err := db.ensureTable(fileID); err != nil {
+		return err
+	}
+	q := fmt.Sprintf(`INSERT INTO %s(ip, city, country, platform, model, os_name, os_version, browser_name, browser_ver)
+        VALUES(?,?,?,?,?,?,?,?,?)`, tableName(fileID))
+	_, err := db.Exec(q, e.IP, e.City, e.Country, e.Platform, e.Model, e.OSName, e.OSVersion, e.BrowserName, e.BrowserVer)
+	return err
+}
+
+// List returns all entries for file sorted by creation time ascending.
+func (db *DB) List(fileID int64) ([]Entry, error) {
+	if err := db.ensureTable(fileID); err != nil {
+		return nil, err
+	}
+	q := fmt.Sprintf(`SELECT id, created_at, ip, city, country, platform, model, os_name, os_version, browser_name, browser_ver FROM %s ORDER BY created_at ASC`, tableName(fileID))
+	rows, err := db.Query(q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []Entry
+	for rows.Next() {
+		var e Entry
+		if err := rows.Scan(&e.ID, &e.CreatedAt, &e.IP, &e.City, &e.Country, &e.Platform, &e.Model, &e.OSName, &e.OSVersion, &e.BrowserName, &e.BrowserVer); err != nil {
+			return nil, err
+		}
+		res = append(res, e)
+	}
+	return res, rows.Err()
+}
+
+// Drop removes log table for file if exists.
+func (db *DB) Drop(fileID int64) error {
+	q := fmt.Sprintf(`DROP TABLE IF EXISTS %s`, tableName(fileID))
+	_, err := db.Exec(q)
+	return err
+}

--- a/server/server.go
+++ b/server/server.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/example/filestoragebot/config"
 	"github.com/example/filestoragebot/db"
+	"github.com/example/filestoragebot/logdb"
 	uaParser "github.com/mssola/user_agent"
 )
 
-func Start(cfg *config.Config, database *db.DB, notify func(int64, string)) error {
+func Start(cfg *config.Config, database *db.DB, logs *logdb.DB, notify func(int64, string)) error {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		slug := path.Base(r.URL.Path)
 		if slug == "" || slug == "." || slug == "/" {
@@ -39,30 +40,42 @@ func Start(cfg *config.Config, database *db.DB, notify func(int64, string)) erro
 		}
 		http.ServeFile(w, r, fp)
 
+		ua := uaParser.New(r.UserAgent())
+		osInfo := ua.OSInfo()
+		platform := ua.Platform()
+		model := ua.Model()
+		browserName, browserVer := ua.Browser()
+
+		ip := r.Header.Get("X-Forwarded-For")
+		if ip == "" {
+			ip, _, _ = net.SplitHostPort(r.RemoteAddr)
+		} else {
+			ip = strings.TrimSpace(strings.Split(ip, ",")[0])
+		}
+
+		var loc struct {
+			City    string `json:"city"`
+			Country string `json:"country"`
+		}
+		if resp, err := http.Get("https://ipinfo.io/" + ip + "/json"); err == nil {
+			data, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			json.Unmarshal(data, &loc)
+		}
+
+		_ = logs.Add(f.ID, &logdb.Entry{
+			IP:          ip,
+			City:        loc.City,
+			Country:     loc.Country,
+			Platform:    platform,
+			Model:       model,
+			OSName:      osInfo.Name,
+			OSVersion:   osInfo.Version,
+			BrowserName: browserName,
+			BrowserVer:  browserVer,
+		})
+
 		if f.Notify && notify != nil {
-			ua := uaParser.New(r.UserAgent())
-			osInfo := ua.OSInfo()
-			platform := ua.Platform()
-			model := ua.Model()
-			browserName, browserVer := ua.Browser()
-
-			ip := r.Header.Get("X-Forwarded-For")
-			if ip == "" {
-				ip, _, _ = net.SplitHostPort(r.RemoteAddr)
-			} else {
-				ip = strings.TrimSpace(strings.Split(ip, ",")[0])
-			}
-
-			var loc struct {
-				City    string `json:"city"`
-				Country string `json:"country"`
-			}
-			if resp, err := http.Get("https://ipinfo.io/" + ip + "/json"); err == nil {
-				data, _ := io.ReadAll(resp.Body)
-				resp.Body.Close()
-				json.Unmarshal(data, &loc)
-			}
-
 			info := fmt.Sprintf("\xF0\x9F\x95\x8B Файл: %s\n\xF0\x9F\x93\x9A \u0422\u0435\u0433: %s\n\xF0\x9F\x8C\x8D IP: %s\n\xF0\x9F\x97\xBD \u041B\u043E\u043A\u0430\u0446\u0438\u044F: %s, %s\n\xF0\x9F\x93\xB1 \u0423\u0441\u0442\u0440\u043E\u0439\u0441\u0442\u0432\u043E: %s %s\n\xF0\x9F\x92\xBB \u041E\u0421: %s %s\n\xF0\x9F\x8C\x90 \u0411\u0440\u0430\u0443\u0437\u0435\u0440: %s %s",
 				f.LocalName, slug, ip, loc.City, loc.Country, platform, model, osInfo.Name, osInfo.Version, browserName, browserVer)
 			notify(f.UserID, info)


### PR DESCRIPTION
## Summary
- track file download data in new SQLite database
- include log database in config and setup
- record download info on each request
- display notification status with emojis
- allow viewing logs via new button and drop logs when file is removed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686d99884c10832a9dac2fa4029b322e